### PR TITLE
Use LITERAL_SCALAR_STYLE for space breaks unless they are trailing

### DIFF
--- a/emitterc.go
+++ b/emitterc.go
@@ -162,10 +162,9 @@ func yaml_emitter_emit(emitter *yaml_emitter_t, event *yaml_event_t) bool {
 // Check if we need to accumulate more events before emitting.
 //
 // We accumulate extra
-//  - 1 event for DOCUMENT-START
-//  - 2 events for SEQUENCE-START
-//  - 3 events for MAPPING-START
-//
+//   - 1 event for DOCUMENT-START
+//   - 2 events for SEQUENCE-START
+//   - 3 events for MAPPING-START
 func yaml_emitter_need_more_events(emitter *yaml_emitter_t) bool {
 	if emitter.events_head == len(emitter.events) {
 		return true
@@ -241,7 +240,7 @@ func yaml_emitter_increase_indent(emitter *yaml_emitter_t, flow, indentless bool
 			emitter.indent += 2
 		} else {
 			// Everything else aligns to the chosen indentation.
-			emitter.indent = emitter.best_indent*((emitter.indent+emitter.best_indent)/emitter.best_indent)
+			emitter.indent = emitter.best_indent * ((emitter.indent + emitter.best_indent) / emitter.best_indent)
 		}
 	}
 	return true
@@ -1360,6 +1359,10 @@ func yaml_emitter_analyze_scalar(emitter *yaml_emitter_t, value []byte) bool {
 		} else {
 			previous_space = false
 			previous_break = false
+		}
+
+		if !is_blankz(value, i) {
+			space_break = false // only count space breaks if they are after all the visibile characters (so trailing spaces at the end of the value)
 		}
 
 		// [Go]: Why 'z'? Couldn't be the end of the string as that's the loop condition.

--- a/encode_test.go
+++ b/encode_test.go
@@ -629,6 +629,8 @@ var marshalerTests = []struct {
 	{"_: 10\n", 10},
 	{"_: null\n", nil},
 	{"_: BAR!\n", "BAR!"},
+	{"_:\n    lines: |-\n        one\n        two\n        three\n", map[interface{}]interface{}{"lines": "one\ntwo\nthree"}},
+	{"_:\n    lines: |-\n        one\n        two \n        three\n", map[interface{}]interface{}{"lines": "one\ntwo \nthree"}},
 }
 
 type marshalerType struct {


### PR DESCRIPTION
This fixes https://github.com/go-yaml/yaml/issues/1013